### PR TITLE
bumping net.ipv4.neigh.default.gc_thresh3 and 2

### DIFF
--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -118,6 +118,8 @@ spec:
       net.ipv4.tcp_mem = 262144 524288 1572864
       net.ipv4.tcp_rmem = 16384 131072 4194304
       net.ipv4.tcp_wmem = 16384 131072 4194304
+      net.ipv4.neigh.default.gc_thresh2 = 4096
+      net.ipv4.neigh.default.gc_thresh3 = 8192
       EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
@@ -157,6 +159,8 @@ spec:
       net.ipv4.tcp_mem = 262144 524288 1572864
       net.ipv4.tcp_rmem = 16384 131072 4194304
       net.ipv4.tcp_wmem = 16384 131072 4194304
+      net.ipv4.neigh.default.gc_thresh2 = 4096
+      net.ipv4.neigh.default.gc_thresh3 = 8192
       EOT
   cloudLabels:
     testground.nodetype: plan
@@ -199,6 +203,8 @@ spec:
       net.ipv4.tcp_mem = 262144 524288 1572864
       net.ipv4.tcp_rmem = 16384 131072 4194304
       net.ipv4.tcp_wmem = 16384 131072 4194304
+      net.ipv4.neigh.default.gc_thresh2 = 4096
+      net.ipv4.neigh.default.gc_thresh3 = 8192
       EOT
   cloudLabels:
     testground.nodetype: infra


### PR DESCRIPTION
Due to seeing `arp_cache: neighbor table overflow!` in `dmesg`.

---

Also visible as `ipv4 errors` in `netdata`.

<img width="1464" alt="Screenshot 2020-04-17 at 21 51 59" src="https://user-images.githubusercontent.com/50459/79608711-c47b9e00-80f5-11ea-8875-4eee61f304ea.png">

I am not 100% sure that these errors are indeed the ARP cache errors, but they did disappear after changing the gc_thresholds.