### PR TITLE
increase weave CONN_LIMIT to 250

### DIFF
--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -178,6 +178,8 @@ items:
               command:
                 - /home/weave/launch.sh
               env:
+                - name: CONN_LIMIT
+                  value: "250"
                 - name: EXTRA_ARGS
                   value: --log-level=info
                 - name: EXPECT_NPC


### PR DESCRIPTION
I think this is necessary if we want to run more than 200 VMs in a weave network.