### PR TITLE
set WEAVE MTU to 8912

### DIFF
--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -178,6 +178,8 @@ items:
               command:
                 - /home/weave/launch.sh
               env:
+                - name: WEAVE_MTU
+                  value: "8912"
                 - name: CONN_LIMIT
                   value: "250"
                 - name: EXTRA_ARGS


### PR DESCRIPTION
Addresses https://github.com/ipfs/testground/issues/871

https://www.weave.works/docs/net/latest/tasks/manage/fastdp/ suggests 8916
https://github.com/kubernetes/kops/issues/2600 suggests 8912

I decided to go with 8912 (we have MTU of 9001 on `eth1`, so this leaves enough room for `84-87 bytes` overhead)

---

Confirmed that this is indeed changing MTU on Weave side, and we don't get errors in logs:

```
INFO: 2020/04/21 09:38:26.351321 sleeve ->[172.20.46.106:6783|ca:38:70:10:90:ba(ip-172-20-46-106.eu-west-2.compute.internal)]: Effective MTU verified at 8939
```