### PR TITLE
Dont monitor plan pods

### DIFF
--- a/k8s/prom-operator.yml
+++ b/k8s/prom-operator.yml
@@ -143,6 +143,9 @@ prometheus:
           topologyKey: "kubernetes.io/hostname"
     nodeSelector:
       testground.nodetype: infra
+    podMonitorSelector:
+      matchExpressions:
+        - { key: testground.purpose, operator: NotIn, values: [ plan ] }
     resources:
       requests:
         memory: 8000Mi


### PR DESCRIPTION
Filter out the plan pods from prometheus monitoring -- these will be monitored separately. 