### PR TITLE
add gp2 volume to influxdb

### DIFF
--- a/k8s/influxdb/values.yaml
+++ b/k8s/influxdb/values.yaml
@@ -50,19 +50,8 @@ service:
 ## Persist data to a persistent volume
 ##
 persistence:
-  enabled: false
-  ## A manually managed Persistent Volume and Claim
-  ## Requires persistence.enabled: true
-  ## If defined, PVC must be created manually before volume will be bound
-  # existingClaim:
-  ## influxdb data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
+  enabled: true
+  storageClass: "gp2"
   annotations:
   accessMode: ReadWriteOnce
   size: 8Gi


### PR DESCRIPTION
This PR is enabling persistence for InfluxDB, by adding a `pv` to the pods (8GB gp2).