### PR TITLE
configurable node types

### DIFF
--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -129,7 +129,7 @@ spec:
       net.ipv4.neigh.default.gc_thresh3 = 32768
       EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c5.4xlarge
+  machineType: ${MASTER_NODE_TYPE}
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -172,7 +172,7 @@ spec:
   cloudLabels:
     testground.nodetype: plan
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c5.2xlarge
+  machineType: ${WORKER_NODE_TYPE}
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}
   nodeLabels:
@@ -217,7 +217,7 @@ spec:
   cloudLabels:
     testground.nodetype: infra
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c5.2xlarge
+  machineType: ${WORKER_NODE_TYPE}
   maxSize: 2
   minSize: 2
   nodeLabels:

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -217,7 +217,7 @@ spec:
   cloudLabels:
     testground.nodetype: infra
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: ${WORKER_NODE_TYPE}
+  machineType: c5.2xlarge
   maxSize: 2
   minSize: 2
   nodeLabels:


### PR DESCRIPTION
Adding configuration env vars for worker and master nodes.

Ideally we should also have a table in install.sh and add warnings in case users try to create large cluster with machines that are not powerful... according to https://kubernetes.io/docs/setup/best-practices/cluster-large/#size-of-master-and-master-components.

TODO:
- [x] update docs to note the 2 new env var params - https://app.gitbook.com/@protocol-labs/s/testground/~/diff/drafts/-M78J6sET8nxa38sz8d2/runner-library/cluster-k8s/how-to-create-a-kubernetes-cluster-for-testground/@drafts