### PR TITLE
Kubernetes Autoscaler

### DIFF
--- a/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -147,11 +147,11 @@ spec:
           name: cluster-autoscaler
           resources:
             limits:
-              cpu: 100m
-              memory: 300Mi
+              cpu: 200m
+              memory: 2048Mi
             requests:
-              cpu: 100m
-              memory: 300Mi
+              cpu: 200m
+              memory: 2048Mi
           command:
             - ./cluster-autoscaler
             - --v=4

--- a/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -143,7 +143,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1
           name: cluster-autoscaler
           resources:
             limits:

--- a/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/k8s/cluster-autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -1,0 +1,171 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
+    spec:
+      serviceAccountName: cluster-autoscaler
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      nodeSelector:
+        kubernetes.io/role: master
+      containers:
+        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${NAME}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-bundle.crt
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -17,8 +17,17 @@ spec:
       [
         {
           "Effect": "Allow",
-          "Action": ["ecr:*"],
-          "Resource": ["*"]
+          "Action": [
+              "ecr:*",
+              "autoscaling:DescribeAutoScalingGroups",
+              "autoscaling:DescribeAutoScalingInstances",
+              "autoscaling:DescribeLaunchConfigurations",
+              "ec2:DescribeLaunchTemplateVersions",
+              "autoscaling:DescribeTags",
+              "autoscaling:SetDesiredCapacity",
+              "autoscaling:TerminateInstanceInAutoScalingGroup"
+          ],
+          "Resource": "*"
         }
       ]
   authorization:
@@ -173,9 +182,11 @@ spec:
       EOT
   cloudLabels:
     testground.node.role.plan: "true"
+    k8s.io/cluster-autoscaler/enabled: ""
+    k8s.io/cluster-autoscaler/${NAME}: ""
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: ${WORKER_NODE_TYPE}
-  maxSize: ${WORKER_NODES}
+  maxSize: 100
   minSize: ${WORKER_NODES}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -13,7 +13,7 @@ spec:
   kubeDNS:
     provider: CoreDNS
   additionalPolicies:
-    node: |
+    master: |
       [
         {
           "Effect": "Allow",
@@ -26,6 +26,16 @@ spec:
               "autoscaling:DescribeTags",
               "autoscaling:SetDesiredCapacity",
               "autoscaling:TerminateInstanceInAutoScalingGroup"
+          ],
+          "Resource": "*"
+        }
+      ]
+    node: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": [
+              "ecr:*"
           ],
           "Resource": "*"
         }

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -91,8 +91,8 @@ spec:
       - net.ipv4.tcp_max_orphans
       - net.ipv4.tcp_abort_on_overflow
     streamingConnectionIdleTimeout: 60m
-    registryPullQPS: 10
-    registryBurst: 20
+    registryPullQPS: 3
+    registryBurst: 6
   kubeControllerManager:
     eventRecordQPS: 20
     eventBurst: 40

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -91,9 +91,16 @@ spec:
       - net.ipv4.tcp_max_orphans
       - net.ipv4.tcp_abort_on_overflow
     streamingConnectionIdleTimeout: 60m
+    registryPullQPS: 10
+    registryBurst: 20
+  kubeControllerManager:
+    eventRecordQPS: 20
+    eventBurst: 40
+    kubeAPIQPS: 20
+    kubeAPIBurst: 40
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.17.3
+  kubernetesVersion: 1.18.3
   masterInternalName: api.internal.${NAME}
   masterPublicName: api.${NAME}
   networkCIDR: 172.20.0.0/16

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -186,8 +186,8 @@ spec:
     k8s.io/cluster-autoscaler/${NAME}: ""
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: ${WORKER_NODE_TYPE}
-  maxSize: 100
-  minSize: ${WORKER_NODES}
+  maxSize: ${MAX_WORKER_NODES}
+  minSize: ${MIN_WORKER_NODES}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
     testground.node.role.plan: "true"

--- a/k8s/install-playbook/validation.sh
+++ b/k8s/install-playbook/validation.sh
@@ -64,6 +64,16 @@ then
   echo -e "Environment variable PUBKEY must be set."
   exit 2
 fi
+if [ -z "$TEAM" ]
+then
+  echo -e "Environment variable TEAM must be set (used for cost-allocation purposes)."
+  exit 2
+fi
+if [ -z "$PROJECT" ]
+then
+  echo -e "Environment variable PROJECT must be set (used for cost-allocation purposes)."
+  exit 2
+fi
 
 # Default values for Optional params
 AUTOSCALER_ENABLED=${AUTOSCALER_ENABLED:false}

--- a/k8s/install-playbook/validation.sh
+++ b/k8s/install-playbook/validation.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -e
+
+# Validate required arguments
+if [ -z "$CLUSTER_SPEC_TEMPLATE" ]
+then
+  echo -e "Please provider cluster spec template file as argument. For example: \`./install.sh cluster.yaml\`"
+  exit 2
+fi
+if [ ! -f "$CLUSTER_SPEC_TEMPLATE" ]; then
+    echo "Provided cluster spec file \"$1\" doesn't exist"
+    exit 2
+fi
+if [ -z "$NAME" ]
+then
+  echo -e "Environment variable NAME must be set."
+  exit 2
+fi
+if [ -z "$KOPS_STATE_STORE" ]
+then
+  echo -e "Environment variable KOPS_STATE_STORE must be set."
+  exit 2
+fi
+if [ -z "$ZONE_A" ]
+then
+  echo -e "Environment variable ZONE_A must be set."
+  exit 2
+fi
+if [ -z "$ZONE_B" ]
+then
+  echo -e "Environment variable ZONE_B must be set."
+  exit 2
+fi
+if [ -z "$AWS_REGION" ]
+then
+  echo -e "Environment variable AWS_REGION must be set."
+  exit 2
+fi
+if [ -z "$WORKER_NODE_TYPE" ]
+then
+  echo -e "Environment variable WORKER_NODE_TYPE must be set."
+  exit 2
+fi
+if [ -z "$MASTER_NODE_TYPE" ]
+then
+  echo -e "Environment variable MASTER_NODE_TYPE must be set."
+  exit 2
+fi
+if [ -z "$MIN_WORKER_NODES" ]
+then
+  echo -e "Environment variable MIN_WORKER_NODES must be set."
+  exit 2
+fi
+if [ -z "$MAX_WORKER_NODES" ]
+then
+  echo -e "Environment variable MAX_WORKER_NODES must be set."
+  exit 2
+fi
+if [ -z "$PUBKEY" ]
+then
+  echo -e "Environment variable PUBKEY must be set."
+  exit 2
+fi
+
+# Default values for Optional params
+AUTOSCALER_ENABLED=${AUTOSCALER_ENABLED:false}
+
+if [ -z "$ULIMIT_NOFILE" ]
+then
+	export ULIMIT_NOFILE="1048576:1048576"
+fi
+

--- a/k8s/install.sh
+++ b/k8s/install.sh
@@ -188,7 +188,7 @@ fi
 echo "Wait for Sidecar to be Ready..."
 echo
 RUNNING_SIDECARS=0
-while [ "$RUNNING_SIDECARS" -ne "$WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl get pods | grep testground-sidecar | grep Running | wc -l || true); echo "Got $RUNNING_SIDECARS running sidecar pods"; sleep 5; done;
+while [ "$RUNNING_SIDECARS" -ne "$MIN_WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl get pods | grep testground-sidecar | grep Running | wc -l || true); echo "Got $RUNNING_SIDECARS running sidecar pods"; sleep 5; done;
 
 echo "Wait for EFS provisioner to be Running..."
 echo

--- a/k8s/install.sh
+++ b/k8s/install.sh
@@ -80,6 +80,11 @@ echo
 
 kubectl apply -f ./limit-range/limit-range.yaml
 
+echo "Install priority class"
+echo
+
+kubectl apply -f ./priority-class/priority-class.yaml
+
 
 echo "Install EFS..."
 

--- a/k8s/install.sh
+++ b/k8s/install.sh
@@ -174,13 +174,16 @@ kubectl apply -f ./testground-daemon/service-account.yml
 kubectl apply -f ./testground-daemon/role-binding.yml
 kubectl apply -f ./testground-daemon/deployment.yml -f ./testground-daemon/service.yml
 
-echo "Install Kubernetes Autoscaler..."
-echo
-pushd cluster-autoscaler
-AUTOSCALER_SPEC=$(mktemp)
-envsubst <cluster-autoscaler-autodiscover.yaml >$AUTOSCALER_SPEC
-kubectl apply -f $AUTOSCALER_SPEC
-popd
+if [ "$AUTOSCALER_ENABLED" = true ]
+then
+  echo "Install Kubernetes Autoscaler..."
+  echo
+  pushd cluster-autoscaler
+  AUTOSCALER_SPEC=$(mktemp)
+  envsubst <cluster-autoscaler-autodiscover.yaml >$AUTOSCALER_SPEC
+  kubectl apply -f $AUTOSCALER_SPEC
+  popd
+fi
 
 echo "Wait for Sidecar to be Ready..."
 echo

--- a/k8s/install.sh
+++ b/k8s/install.sh
@@ -158,6 +158,14 @@ kubectl apply -f ./testground-daemon/service-account.yml
 kubectl apply -f ./testground-daemon/role-binding.yml
 kubectl apply -f ./testground-daemon/deployment.yml -f ./testground-daemon/service.yml
 
+echo "Install Kubernetes Autoscaler..."
+echo
+pushd cluster-autoscaler
+AUTOSCALER_SPEC=$(mktemp)
+envsubst <cluster-autoscaler-autodiscover.yaml >$AUTOSCALER_SPEC
+kubectl apply -f $AUTOSCALER_SPEC
+popd
+
 echo "Wait for Sidecar to be Ready..."
 echo
 RUNNING_SIDECARS=0

--- a/k8s/kops-weave/dummy.yml
+++ b/k8s/kops-weave/dummy.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         name: dummy
     spec:
+      priorityClassName: high-priority
       volumes:
       - name: host-sys
         hostPath:

--- a/k8s/kops-weave/dummy.yml
+++ b/k8s/kops-weave/dummy.yml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
   labels:
     k8s-app: dummy
+  annotations:
+    cni: "flannel"
 spec:
   selector:
     matchLabels:
@@ -13,8 +15,10 @@ spec:
     metadata:
       labels:
         name: dummy
+      annotations:
+        cni: "flannel"
     spec:
-      priorityClassName: high-priority
+      priorityClassName: system-node-critical
       volumes:
       - name: host-sys
         hostPath:

--- a/k8s/kops-weave/dummy.yml
+++ b/k8s/kops-weave/dummy.yml
@@ -24,6 +24,6 @@ spec:
         command: ["/bin/sleep", "3650d"]
         image: governmentpaas/curl-ssl
         resources:
-          limits:
-            cpu: 10m
+          requests:
+            cpu: 100m
             memory: 10Mi

--- a/k8s/kops-weave/flannel.yml
+++ b/k8s/kops-weave/flannel.yml
@@ -168,6 +168,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
+      priorityClassName: high-priority
       initContainers:
       - name: install-cni
         image: quay.io/coreos/flannel:v0.11.0-amd64

--- a/k8s/kops-weave/flannel.yml
+++ b/k8s/kops-weave/flannel.yml
@@ -168,7 +168,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
-      priorityClassName: high-priority
+      priorityClassName: system-node-critical
       initContainers:
       - name: install-cni
         image: quay.io/coreos/flannel:v0.11.0-amd64

--- a/k8s/kops-weave/genie-plugin.yaml
+++ b/k8s/kops-weave/genie-plugin.yaml
@@ -129,6 +129,16 @@ spec:
       hostPID: true
       serviceAccountName: genie-plugin
       priorityClassName: system-node-critical
+      initContainers:
+      - name: wait-for-flannel
+        image: busybox
+        securityContext:
+          privileged: true
+        command:
+        - sh
+        - -ac
+        - >
+          while [ "$FLANNEL_ROUTES" = "" ]; do export FLANNEL_ROUTES=$(ip route | grep flannel.1); echo "Got FLANNEL_ROUTES: $FLANNEL_ROUTES"; sleep 5; done;
       containers:
         # Create a container with install.sh that
         # Installs required 00-genie.conf and genie binary

--- a/k8s/kops-weave/genie-plugin.yaml
+++ b/k8s/kops-weave/genie-plugin.yaml
@@ -128,7 +128,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: genie-plugin
-      priorityClassName: high-priority
+      priorityClassName: system-node-critical
       containers:
         # Create a container with install.sh that
         # Installs required 00-genie.conf and genie binary

--- a/k8s/kops-weave/genie-plugin.yaml
+++ b/k8s/kops-weave/genie-plugin.yaml
@@ -128,6 +128,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: genie-plugin
+      priorityClassName: high-priority
       containers:
         # Create a container with install.sh that
         # Installs required 00-genie.conf and genie binary

--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -163,7 +163,7 @@ items:
           labels:
             name: weave-net
         spec:
-          priorityClassName: high-priority
+          priorityClassName: system-node-critical
           initContainers:
           - name: wait-for-flannel
             image: busybox

--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -204,7 +204,7 @@ items:
                 timeoutSeconds: 5
               resources:
                 requests:
-                  cpu: 1000m
+                  cpu: 100m
                   memory: 1536Mi
                 limits:
                   memory: 1536Mi

--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -163,6 +163,7 @@ items:
           labels:
             name: weave-net
         spec:
+          priorityClassName: high-priority
           initContainers:
           - name: wait-for-flannel
             image: busybox

--- a/k8s/priority-class/priority-class.yaml
+++ b/k8s/priority-class/priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for all Testground sysmtem service pods that live on the worker nodes (flannel, weave, cni-genie, dummy, etc.)."

--- a/k8s/sidecar.yaml
+++ b/k8s/sidecar.yaml
@@ -15,6 +15,7 @@ spec:
       hostPID: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: high-priority
       initContainers:
       - name: iproute-add
         image: busybox

--- a/k8s/testground-daemon/config-map-env-toml.yml
+++ b/k8s/testground-daemon/config-map-env-toml.yml
@@ -13,6 +13,7 @@ data:
     testplan_pod_memory         = "100Mi"
     collect_outputs_pod_cpu     = "1000m"
     collect_outputs_pod_memory  = "1000Mi"
+    autoscaler_enabled          = true
     provider                    = "aws"
     sysctls = [
       "net.core.somaxconn=10000",


### PR DESCRIPTION
This PR is adding k8s autoscaler behind a feature flag, so that we can start experimenting with it - users can enable it by setting an environment variable, and by default it is disabled.

I am also adding a bit stricter validation of required env vars, so that folks avoid silent failures in case they forget to set a required param (such as `WORKER_NODE_TYPE`).

To be reviewed and merged together with https://github.com/testground/testground/pull/1057

TODO:
- [x] move additional permissions for autoscaler only to master node

---

KNOWN ISSUES:
- [ ] address pods failing with `OutOfcpu` errors:
```
Warning  OutOfcpu   45s   kubelet, ip-172-20-78-29.eu-west-2.compute.internal  Node didn't have enough resource: cpu, requested: 100, used: 8000, capacity: 8000
```
Related:
1. https://github.com/kubernetes/kubernetes/issues/34772#issuecomment-260367534
2. https://github.com/kubernetes/kubernetes/issues/86626
3. https://github.com/kubernetes/kubernetes/pull/73845

- [ ] NotTriggerScaleUp
```
Normal   NotTriggerScaleUp  113s (x3 over 2m14s)  cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added):
Warning  FailedScheduling   36s (x6 over 2m19s)   default-scheduler   0/44 nodes are available: 3 node(s) didn't match node selector, 41 Insufficient cpu.
```