### PR TITLE
shard kube-state-metrics

### DIFF
--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -218,8 +218,8 @@ spec:
     testground.node.role.infra: "true"
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
-  maxSize: 2
-  minSize: 2
+  maxSize: 3
+  minSize: 3
   nodeLabels:
     kops.k8s.io/instancegroup: tginfra
     testground.node.role.infra: "true"

--- a/k8s/prometheus-operator/values.yaml
+++ b/k8s/prometheus-operator/values.yaml
@@ -122,7 +122,11 @@ kubeEtcd:
     insecureSkipVerify: true
     https: false
 kubeStateMetrics:
-  enabled: false
+  enabled: true
+kube-state-metrics:
+  replicas: 3
+  autosharding:
+    enabled: true
 prometheus:
   prometheusSpec:
     serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
experimenting with sharding prometheus data.

Just by introducing sharding at the kube-state-metrics level has a surprising, but obviously limited improvement. WIth a single prometheus and three kube-state-metrics with auto-sharding enabled, I can run reasonably large clusters ( ~5k pods ) without prometheus hitting the oom killer in our current configuration. This is a heap map taken while running 5k pods on a 75 node cluster with only this change.

![heap75](https://user-images.githubusercontent.com/8444698/83625250-7eb15280-a548-11ea-9393-5f927b4c4c34.png)

We need to do some re-labeling to shard on prometheus itself. We can do this if we switch away from using the operator, or there is a PR in the works, it appears, to add prometheus sharding to the operator which we could definitely benefit from once finished:

https://github.com/coreos/prometheus-operator/pull/3241
