### PR TITLE
bump weave memory

### DIFF
--- a/k8s/kops-weave/weave.yml
+++ b/k8s/kops-weave/weave.yml
@@ -204,9 +204,9 @@ items:
               resources:
                 requests:
                   cpu: 1000m
-                  memory: 1024Mi
+                  memory: 1536Mi
                 limits:
-                  memory: 1024Mi
+                  memory: 1536Mi
               securityContext:
                 privileged: true
               volumeMounts:


### PR DESCRIPTION
On 250 node cluster, weave is going OOM with 1GB of RAM.