### PR TITLE
use edge image tag

### DIFF
--- a/k8s/sidecar.yaml
+++ b/k8s/sidecar.yaml
@@ -34,7 +34,7 @@ spec:
           echo "redis-headless resolved."
       containers:
       - name: testground-sidecar
-        image: iptestground/sidecar:v0.5.1
+        image: iptestground/sidecar:edge
         imagePullPolicy: Always
         command: ["testground"]
         args: ["sidecar", "--runner", "k8s"]

--- a/k8s/sidecar.yaml
+++ b/k8s/sidecar.yaml
@@ -37,7 +37,7 @@ spec:
         image: iptestground/sidecar:v0.5.1
         imagePullPolicy: Always
         command: ["testground"]
-        args: ["sidecar", "--runner", "k8s", "--pprof"]
+        args: ["sidecar", "--runner", "k8s"]
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "SYS_ADMIN", "SYS_TIME"]

--- a/k8s/testground-daemon/deployment.yml
+++ b/k8s/testground-daemon/deployment.yml
@@ -55,7 +55,7 @@ spec:
             memory: 512Mi
             cpu: 500m
       - name: testground-daemon
-        image: iptestground/testground:v0.5.1
+        image: iptestground/testground:edge
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
`v0.5.1` tag is pointing to a commit, where we have locked the image versions of Testground (daemon and sidecar) and the Kubernetes resources specs to v0.5.1, so this commit is making sure that the `testground/infra` playbooks play nicely with the `master`/`edge` version on `testground/testground`.