### PR TITLE
add netdata to Testground AMI

### DIFF
--- a/k8s/packer/docker-pull-images.sh
+++ b/k8s/packer/docker-pull-images.sh
@@ -30,3 +30,6 @@ pushd $TEMPDIR
 wget https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 sudo docker load < protokube.tar.gz
 popd
+
+wget -O /tmp/kickstart-static64.sh https://my-netdata.io/kickstart-static64.sh
+sh /tmp/kickstart-static64.sh --dont-wait --no-updates

--- a/k8s/tools/authorize-19999.sh
+++ b/k8s/tools/authorize-19999.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+securityGroupId=`aws ec2 describe-security-groups --region=$AWS_REGION --output text | awk '/nodes.'$NAME'/ && /SECURITYGROUPS/ { print $6 };'`
+
+if [[ -z ${securityGroupId} ]]; then
+  echo "Couldn't detect AWS Security Group created by `kops`"
+  exit 1
+fi
+
+aws ec2 authorize-security-group-ingress \
+    --group-id $securityGroupId \
+    --ip-permissions IpProtocol=tcp,FromPort=19999,ToPort=19999,IpRanges='[{CidrIp=0.0.0.0/0}]'


### PR DESCRIPTION
That could be an alternative for the short-term until we get Prometheus + Grafana dashboards + node_exporter working as we need it.