### PR TITLE
set v0.5.3 tag for images - daemon and sidecar

### DIFF
--- a/k8s/sidecar.yaml
+++ b/k8s/sidecar.yaml
@@ -35,7 +35,7 @@ spec:
           echo "redis-headless resolved."
       containers:
       - name: testground-sidecar
-        image: iptestground/sidecar:edge
+        image: iptestground/sidecar:v0.5.3
         imagePullPolicy: Always
         command: ["testground"]
         args: ["sidecar", "--runner", "k8s"]

--- a/k8s/testground-daemon/deployment.yml
+++ b/k8s/testground-daemon/deployment.yml
@@ -53,7 +53,7 @@ spec:
           limits:
             memory: 512Mi
       - name: testground-daemon
-        image: iptestground/testground:edge
+        image: iptestground/testground:v0.5.3
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Once images are released, we should lock the current version of `infra` with this PR, and tag v0.5.3 testground/infra as well, to correspond with the Testground version.