### PR TITLE
add owner to ami image name

### DIFF
--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -139,7 +139,7 @@ spec:
       net.ipv4.neigh.default.gc_thresh2 = 4096
       net.ipv4.neigh.default.gc_thresh3 = 32768
       EOT
-  image: testground_2020-06-09
+  image: 909427826938/testground_2020-06-09
   machineType: ${MASTER_NODE_TYPE}
   maxSize: 1
   minSize: 1
@@ -182,7 +182,7 @@ spec:
       EOT
   cloudLabels:
     testground.node.role.plan: "true"
-  image: testground_2020-06-09
+  image: 909427826938/testground_2020-06-09
   machineType: ${WORKER_NODE_TYPE}
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}
@@ -227,7 +227,7 @@ spec:
       EOT
   cloudLabels:
     testground.node.role.infra: "true"
-  image: testground_2020-06-09
+  image: 909427826938/testground_2020-06-09
   machineType: c5.2xlarge
   maxSize: 2
   minSize: 2


### PR DESCRIPTION
Our AMI is public, but it is necessary to also have the owner as a prefix for other AWS accounts to be able to find it.

The current versions works only from the Testground AWS account.