### PR TITLE
split install.sh script into multiple scripts

### DIFF
--- a/k8s/01_install_k8s.sh
+++ b/k8s/01_install_k8s.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o pipefail
-
 set -e
 
 err_report() {
@@ -23,7 +22,8 @@ source "$my_dir/install-playbook/validation.sh"
 
 echo "Required arguments"
 echo "------------------"
-echo "Name (NAME): $NAME"
+echo "Deployment name (DEPLOYMENT_NAME): $DEPLOYMENT_NAME"
+echo "Cluster name (CLUSTER_NAME): $CLUSTER_NAME"
 echo "Kops state store (KOPS_STATE_STORE): $KOPS_STATE_STORE"
 echo "AWS availability zone A (ZONE_A): $ZONE_A"
 echo "AWS availability zone B (ZONE_B): $ZONE_B"
@@ -52,8 +52,8 @@ fi
 # The remainder of this script creates the cluster using the generated template
 
 kops create -f $CLUSTER_SPEC
-kops create secret --name $NAME sshpublickey admin -i $PUBKEY
-kops update cluster $NAME --yes
+kops create secret --name $CLUSTER_NAME sshpublickey admin -i $PUBKEY
+kops update cluster $CLUSTER_NAME --yes
 
 # Wait for worker nodes and master to be ready
 kops validate cluster --wait 20m
@@ -65,62 +65,6 @@ echo "Install default container limits"
 echo
 
 kubectl apply -f ./limit-range/limit-range.yaml
-
-echo "Install EFS..."
-
-vpcId=`aws ec2 describe-vpcs --region=$AWS_REGION --filters Name=tag:Name,Values=$NAME --output text | awk '/VPCS/ { print $8 }'`
-
-if [[ -z ${vpcId} ]]; then
-  echo "Couldn't detect AWS VPC created by `kops`"
-  exit 1
-fi
-
-echo "Detected VPC: $vpcId"
-
-securityGroupId=`aws ec2 describe-security-groups --region=$AWS_REGION --output text | awk '/nodes.'$NAME'/ && /SECURITYGROUPS/ { print $6 };'`
-
-if [[ -z ${securityGroupId} ]]; then
-  echo "Couldn't detect AWS Security Group created by `kops`"
-  exit 1
-fi
-
-echo "Detected Security Group ID: $securityGroupId"
-
-subnetIdZoneA=`aws ec2 describe-subnets --region=$AWS_REGION --output text | awk '/'$vpcId'/ { print $13 }' | sort | head -1`
-subnetIdZoneB=`aws ec2 describe-subnets --region=$AWS_REGION --output text | awk '/'$vpcId'/ { print $13 }' | sort | tail -1`
-
-echo "Detected Subnet: $subnetIdZoneA"
-echo "Detected Subnet: $subnetIdZoneB"
-
-pushd efs-terraform
-
-# extract s3 bucket from kops state store
-S3_BUCKET="${KOPS_STATE_STORE:5:100}"
-
-terraform init -backend-config=bucket=$S3_BUCKET \
-               -backend-config=key=tf-efs-$NAME \
-               -backend-config=region=$AWS_REGION
-
-terraform apply -var aws_region=$AWS_REGION -var fs_subnet_id_zone_a=$subnetIdZoneA -var fs_subnet_id_zone_b=$subnetIdZoneB -var fs_sg_id=$securityGroupId -auto-approve
-
-export EFS_DNSNAME=`terraform output dns_name`
-
-fsId=`terraform output filesystem_id`
-
-popd
-
-echo "Install EFS Kubernetes provisioner..."
-
-kubectl create configmap efs-provisioner \
---from-literal=file.system.id=$fsId \
---from-literal=aws.region=$AWS_REGION \
---from-literal=provisioner.name=testground.io/aws-efs
-
-EFS_MANIFEST_SPEC=$(mktemp)
-envsubst <./efs/manifest.yaml.spec >$EFS_MANIFEST_SPEC
-
-kubectl apply -f ./efs/rbac.yaml \
-              -f $EFS_MANIFEST_SPEC
 
 echo "Install Weave, CNI-Genie, Sidecar Daemonset..."
 echo
@@ -152,24 +96,12 @@ echo
 kubectl apply -f ./kops-weave/weave-metrics-service.yml \
               -f ./kops-weave/weave-service-monitor.yml
 
-echo "Install Testground daemon..."
-echo
-kubectl apply -f ./testground-daemon/config-map-env-toml.yml
-kubectl apply -f ./testground-daemon/service-account.yml
-kubectl apply -f ./testground-daemon/role-binding.yml
-kubectl apply -f ./testground-daemon/deployment.yml -f ./testground-daemon/service.yml
-
 echo "Wait for Sidecar to be Ready..."
 echo
 RUNNING_SIDECARS=0
 while [ "$RUNNING_SIDECARS" -ne "$WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl get pods | grep testground-sidecar | grep Running | wc -l || true); echo "Got $RUNNING_SIDECARS running sidecar pods"; sleep 5; done;
 
-echo "Wait for EFS provisioner to be Running..."
-echo
-RUNNING_EFS=0
-while [ "$RUNNING_EFS" -ne 1 ]; do RUNNING_EFS=$(kubectl get pods | grep efs-provisioner | grep Running | wc -l || true); echo "Got $RUNNING_EFS running efs-provisioner pods"; sleep 5; done;
-
-echo "Testground cluster is ready"
+echo "Testground cluster is installed"
 echo
 
 END_TIME=`date +%s`

--- a/k8s/02_efs.sh
+++ b/k8s/02_efs.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -e
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR
+
+START_TIME=`date +%s`
+
+my_dir="$(dirname "$0")"
+source "$my_dir/install-playbook/validation.sh"
+
+echo "Installing EFS..."
+
+vpcId=`aws ec2 describe-vpcs --region=$AWS_REGION --filters Name=tag:Name,Values=$NAME --output text | awk '/VPCS/ { print $8 }'`
+
+if [[ -z ${vpcId} ]]; then
+  echo "Couldn't detect AWS VPC created by `kops`"
+  exit 1
+fi
+
+echo "Detected VPC: $vpcId"
+
+securityGroupId=`aws ec2 describe-security-groups --region=$AWS_REGION --output text | awk '/nodes.'$NAME'/ && /SECURITYGROUPS/ { print $6 };'`
+
+if [[ -z ${securityGroupId} ]]; then
+  echo "Couldn't detect AWS Security Group created by `kops`"
+  exit 1
+fi
+
+echo "Detected Security Group ID: $securityGroupId"
+
+subnetIdZoneA=`aws ec2 describe-subnets --region=$AWS_REGION --output text | awk '/'$vpcId'/ { print $13 }' | sort | head -1`
+subnetIdZoneB=`aws ec2 describe-subnets --region=$AWS_REGION --output text | awk '/'$vpcId'/ { print $13 }' | sort | tail -1`
+
+echo "Detected Subnet: $subnetIdZoneA"
+echo "Detected Subnet: $subnetIdZoneB"
+
+pushd efs-terraform
+
+# extract s3 bucket from kops state store
+S3_BUCKET="${KOPS_STATE_STORE:5:100}"
+
+# create EFS file system
+terraform init -backend-config=bucket=$S3_BUCKET \
+               -backend-config=key=${DEPLOYMENT_NAME}-efs \
+               -backend-config=region=$AWS_REGION
+
+terraform apply -var aws_region=$AWS_REGION -var fs_subnet_id_zone_a=$subnetIdZoneA -var fs_subnet_id_zone_b=$subnetIdZoneB -var fs_sg_id=$securityGroupId -auto-approve
+
+export EFS_DNSNAME=`terraform output dns_name`
+
+fsId=`terraform output filesystem_id`
+
+popd
+
+echo "Install EFS Kubernetes provisioner..."
+
+kubectl create configmap efs-provisioner \
+--from-literal=file.system.id=$fsId \
+--from-literal=aws.region=$AWS_REGION \
+--from-literal=provisioner.name=testground.io/aws-efs
+
+EFS_MANIFEST_SPEC=$(mktemp)
+envsubst <./efs/manifest.yaml.spec >$EFS_MANIFEST_SPEC
+
+kubectl apply -f ./efs/rbac.yaml \
+              -f $EFS_MANIFEST_SPEC
+
+echo "Wait for EFS provisioner to be Running..."
+echo
+RUNNING_EFS=0
+while [ "$RUNNING_EFS" -ne 1 ]; do RUNNING_EFS=$(kubectl get pods | grep efs-provisioner | grep Running | wc -l || true); echo "Got $RUNNING_EFS running efs-provisioner pods"; sleep 5; done;
+
+echo "EFS provisioner is ready"
+echo
+
+END_TIME=`date +%s`
+echo "Execution time was `expr $END_TIME - $START_TIME` seconds"

--- a/k8s/03_ebs.sh
+++ b/k8s/03_ebs.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -e
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR
+
+START_TIME=`date +%s`
+
+my_dir="$(dirname "$0")"
+source "$my_dir/install-playbook/validation.sh"
+
+echo "Installing EBS..."
+
+# extract s3 bucket from kops state store
+S3_BUCKET="${KOPS_STATE_STORE:5:100}"
+
+# create EBS volume for testground datadir
+pushd ebs-terraform
+
+terraform init -backend-config=bucket=$S3_BUCKET \
+               -backend-config=key=${DEPLOYMENT_NAME}-ebs \
+               -backend-config=region=$AWS_REGION
+
+terraform apply -var aws_region=$AWS_REGION -var aws_availability_zone=${AWS_REGION}a -auto-approve
+
+export TG_EBS_DATADIR_VOLUME_ID="aws://`terraform output availability_zone`/`terraform output volume_id`"
+
+popd
+
+echo "Got volume id for Testground datadir: $TG_EBS_DATADIR_VOLUME_ID"
+
+EBS_PV=$(mktemp)
+envsubst <./ebs/pv.yml.spec >$EBS_PV
+
+kubectl apply -f ./ebs/storageclass.yml \
+              -f $EBS_PV \
+              -f ./ebs/pvc.yml
+
+
+echo "EBS volume for Testground daemon is ready"
+echo
+
+END_TIME=`date +%s`
+echo "Execution time was `expr $END_TIME - $START_TIME` seconds"

--- a/k8s/04_testground_daemon.sh
+++ b/k8s/04_testground_daemon.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -e
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR
+
+START_TIME=`date +%s`
+
+my_dir="$(dirname "$0")"
+source "$my_dir/install-playbook/validation.sh"
+
+echo "Installing Testground daemon..."
+echo
+kubectl apply -f ./testground-daemon/config-map-env-toml.yml
+kubectl apply -f ./testground-daemon/service-account.yml
+kubectl apply -f ./testground-daemon/role-binding.yml
+kubectl apply -f ./testground-daemon/deployment.yml -f ./testground-daemon/service.yml
+
+echo "Testground daemon is ready"
+echo
+
+END_TIME=`date +%s`
+echo "Execution time was `expr $END_TIME - $START_TIME` seconds"
+

--- a/k8s/delete_ebs.sh
+++ b/k8s/delete_ebs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+set -e
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR
+
+pushd ebs-terraform
+
+# extract s3 bucket from kops state store
+S3_BUCKET="${KOPS_STATE_STORE:5:100}"
+
+terraform init -backend-config=bucket=$S3_BUCKET \
+               -backend-config=key=${DEPLOYMENT_NAME}-ebs \
+               -backend-config=region=$AWS_REGION
+
+terraform destroy -var aws_region=$AWS_REGION -var aws_availability_zone=${AWS_REGION}a -auto-approve
+
+popd

--- a/k8s/delete_efs.sh
+++ b/k8s/delete_efs.sh
@@ -3,7 +3,6 @@
 set -o errexit
 set -o pipefail
 set -x
-
 set -e
 
 err_report() {
@@ -48,5 +47,3 @@ terraform init -backend-config=bucket=$S3_BUCKET \
 terraform destroy -var aws_region=$AWS_REGION -var fs_subnet_id_zone_a=$subnetIdZoneA -var fs_subnet_id_zone_b=$subnetIdZoneB -var fs_sg_id=$securityGroupId -auto-approve
 
 popd
-
-kops delete cluster $NAME --yes

--- a/k8s/delete_kops.sh
+++ b/k8s/delete_kops.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+set -e
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR
+
+kops delete cluster $NAME --yes

--- a/k8s/ebs-terraform/backend.tf
+++ b/k8s/ebs-terraform/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/k8s/ebs-terraform/ebs.tf
+++ b/k8s/ebs-terraform/ebs.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.50"
+}
+
+# EBS for Testground daemon datadir
+resource "aws_ebs_volume" "testground-daemon-datadir" {
+  availability_zone = var.aws_availability_zone
+  size = 10
+  type = "gp2"
+
+  tags = "${merge(var.default_tags)}"
+}

--- a/k8s/ebs-terraform/outputs.tf
+++ b/k8s/ebs-terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "volume_id" {
+  value       = aws_ebs_volume.testground-daemon-datadir.id
+}
+
+output "availability_zone" {
+  value       = var.aws_availability_zone
+}
+

--- a/k8s/ebs-terraform/variables.tf
+++ b/k8s/ebs-terraform/variables.tf
@@ -1,0 +1,12 @@
+variable "aws_region" {}
+
+variable "aws_availability_zone" {}
+
+variable "default_tags" {
+  type = "map"
+
+  default = {
+    Name              = "taas-daemon-datadir-volume"
+    KubernetesCluster = "anton-kops.k8s.local"
+  }
+}

--- a/k8s/ebs/pv.yml.spec
+++ b/k8s/ebs/pv.yml.spec
@@ -1,0 +1,15 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: testground-daemon-datadir-pv
+  labels:
+    type: aws-ebs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "gp2-retain"
+  awsElasticBlockStore:
+    volumeID: ${TG_EBS_DATADIR_VOLUME_ID}
+    fsType: ext4

--- a/k8s/ebs/pvc.yml
+++ b/k8s/ebs/pvc.yml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testground-daemon-datadir-pvc
+  labels:
+    type: aws-ebs
+spec:
+  storageClassName: "gp2-retain"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/ebs/storageclass.yml
+++ b/k8s/ebs/storageclass.yml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gp2-retain
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+mountOptions:
+  - debug
+volumeBindingMode: Immediate

--- a/k8s/efs-terraform/efs.tf
+++ b/k8s/efs-terraform/efs.tf
@@ -3,6 +3,7 @@ provider "aws" {
   version = "~> 2.50"
 }
 
+# EFS for Testground outputs
 resource "aws_efs_file_system" "default" {
   count           = 1
 }

--- a/k8s/install-playbook/validation.sh
+++ b/k8s/install-playbook/validation.sh
@@ -14,9 +14,14 @@ if [ ! -f "$CLUSTER_SPEC_TEMPLATE" ]; then
     echo "Provided cluster spec file \"$1\" doesn't exist"
     exit 2
 fi
-if [ -z "$NAME" ]
+if [ -z "$CLUSTER_NAME" ]
 then
-  echo -e "Environment variable NAME must be set."
+  echo -e "Environment variable CLUSTER_NAME must be set."
+  exit 2
+fi
+if [ -z "$DEPLOYMENT_NAME" ]
+then
+  echo -e "Environment variable DEPLOYMENT_NAME must be set."
   exit 2
 fi
 if [ -z "$KOPS_STATE_STORE" ]

--- a/k8s/testground-daemon/config-map-env-toml.yml
+++ b/k8s/testground-daemon/config-map-env-toml.yml
@@ -9,6 +9,7 @@ data:
     region = "eu-west-2"
 
     [runners."cluster:k8s"]
+    run_timeout_min             = 15
     testplan_pod_cpu            = "100m"
     testplan_pod_memory         = "100Mi"
     collect_outputs_pod_cpu     = "1000m"
@@ -20,6 +21,13 @@ data:
 
     [daemon]
     listen = "0.0.0.0:8042"
+    slack_webhook_url = ""
+    github_repo_status_token = ""
+
+    [daemon.scheduler]
+    workers = 2
+    task_timeout_min  = 20
+    task_repo_type    = "disk"
 
     [client]
     endpoint = "localhost:8080"

--- a/k8s/testground-daemon/deployment.yml
+++ b/k8s/testground-daemon/deployment.yml
@@ -44,7 +44,7 @@ spec:
           - name: envtoml
             mountPath: /root/testground/.env.toml
             subPath: .env.toml
-          - name: goproxymnt-pvc
+          - name: efs-pvc
             mountPath: "/go"
         resources:
           requests:
@@ -55,12 +55,19 @@ spec:
       - name: testground-daemon
         image: iptestground/testground:edge
         imagePullPolicy: Always
+        env:
+        - name: REDIS_HOST
+          value: "testground-infra-redis-headless"
         securityContext:
           privileged: true
         ports:
         - containerPort: 8042
           hostPort: 8042
         volumeMounts:
+          - name: daemon-datadir
+            mountPath: "/root/testground/"
+          - name: efs-pvc
+            mountPath: "/efs"
           - name: dockersock
             mountPath: "/var/run/docker.sock"
           - name: envtoml
@@ -68,14 +75,17 @@ spec:
             subPath: .env.toml
         resources:
           requests:
-            memory: 2000Mi
+            memory: 2048Mi
             cpu: 2000m
           limits:
-            memory: 2000Mi
+            memory: 2048Mi
       volumes:
-        - name: goproxymnt-pvc
+        - name: efs-pvc
           persistentVolumeClaim:
             claimName: efs
+        - name: daemon-datadir
+          persistentVolumeClaim:
+            claimName: testground-daemon-datadir-pvc
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock

--- a/k8s/testground-daemon/role-binding.yml
+++ b/k8s/testground-daemon/role-binding.yml
@@ -8,7 +8,7 @@ rules:
   #
   # at the HTTP level, the name of the resource for accessing Secret
   # objects is "secrets"
-  resources: ["pods", "nodes", "pods/log", "pods/exec"]
+  resources: ["pods", "nodes", "pods/log", "pods/exec", "events", "persistentvolumeclaims", "persistentvolumes"]
   verbs: ["get", "watch", "list", "edit", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s/upgrade-testground-infra.sh
+++ b/k8s/upgrade-testground-infra.sh
@@ -1,9 +1,0 @@
-#/usr/bin/env bash
-
-# Updates sub-charts not managed by the testground team.
-
-HERE=$(dirname $0)
-pushd "$HERE"/testground-infra
-helm dep build
-helm upgrade --atomic --install testground-infra .
-popd


### PR DESCRIPTION
This PR is addressing https://github.com/testground/testground/issues/1166 and https://github.com/testground/testground/issues/1129

---

1. It is splitting the `install.sh` script into multiple scripts, so that these playbooks accommodate both for adhoc Kubernetes deployments (those that we have been creating until now), as well as Testground as a Server / upgradeable environment - one where you would want to be able to upgrade the Kubernetes cluster, but keep EFS and EBS in tact.

2. It is splitting the global `$NAME` variable into `$DEPLOYMENT_NAME` and `$CLUSTER_NAME` - the rational is that DEPLOYMENT encompasses EBS, EFS and the Kubernetes cluster, whereas CLUSTER_NAME refers only to the Kubernetes cluster. This way we can create a new cluster, and easily attach it to an existing EFS file system and EBS volume (obviously the cluster needs to be in the same AWS region).

3. It is adding EBS playbooks - until now we were storing the Testground datadir on a volume on the host EC2 instance. Now we are using an EBS volume for that purpose.