### PR TITLE
Update 01_install_k8s.sh to export cluster admin user credential

### DIFF
--- a/k8s/01_install_k8s.sh
+++ b/k8s/01_install_k8s.sh
@@ -53,7 +53,7 @@ fi
 
 kops create -f $CLUSTER_SPEC
 kops create secret --name $CLUSTER_NAME sshpublickey admin -i $PUBKEY
-kops update cluster $CLUSTER_NAME --yes
+kops update cluster $CLUSTER_NAME --yes --admin
 
 # Wait for worker nodes and master to be ready
 kops validate cluster --wait 20m


### PR DESCRIPTION
Without this, the script would print the following:
```
I0521 14:47:08.960811   31083 update_cluster.go:313] Exporting kubecfg for cluster
kops has set your kubectl context to <...>
W0521 14:47:09.316060   31083 update_cluster.go:337] Exported kubecfg with no user authentication; use --admin, --user or --auth-plugin flags with `kops export kubecfg`
...
W0521 14:44:51.631147   30814 validate_cluster.go:173] (will retry): unexpected error during validation: error listing nodes: Unauthorized
...
```

Even if the user run `kops update cluster` with `--admin` manually as instructed, the existing `kops` session would still fail.