### PR TITLE
Auth fix for kops>=1.19

### DIFF
--- a/k8s/01_install_k8s.sh
+++ b/k8s/01_install_k8s.sh
@@ -56,6 +56,7 @@ kops create secret --name $CLUSTER_NAME sshpublickey admin -i $PUBKEY
 kops update cluster $CLUSTER_NAME --yes
 
 # Wait for worker nodes and master to be ready
+kops export kubecfg --admin --name $CLUSTER_NAME 
 kops validate cluster --wait 20m
 
 echo "Cluster nodes are Ready"


### PR DESCRIPTION
My KOps was unable to auth in the validation step. 
I added a line to remind KOps to use the admin user.

```
# Wait for worker nodes and master to be ready
kops export kubecfg --admin --name $CLUSTER_NAME 
kops validate cluster --wait 20m
```