### PR TITLE
Fixes #1377 Bitnami redis chart version upgrade

### DIFF
--- a/k8s/01_install_k8s.sh
+++ b/k8s/01_install_k8s.sh
@@ -87,7 +87,7 @@ popd
 
 echo "Installing Redis and Grafana dashboards"
 pushd testground-infra
-helm dep build
+helm dep update
 helm dep build
 helm install testground-infra .
 popd

--- a/k8s/01_install_k8s.sh
+++ b/k8s/01_install_k8s.sh
@@ -88,6 +88,7 @@ popd
 echo "Installing Redis and Grafana dashboards"
 pushd testground-infra
 helm dep build
+helm dep build
 helm install testground-infra .
 popd
 

--- a/k8s/testground-infra/values.yaml
+++ b/k8s/testground-infra/values.yaml
@@ -22,7 +22,9 @@ redis:
         memory: 256Mi
   cluster:
     enabled: false
-  usePassword: false
+
+  auth:
+    enabled: false
   securityContext:
     sysctls:
       - name: net.core.somaxconn


### PR DESCRIPTION
Upgrading the Redis Chart from 10.6.6 which is no longer available.