### PR TITLE
( #1236) Block all other runners when deploying the daemon

### DIFF
--- a/k8s/testground-daemon/config-map-env-toml.yml
+++ b/k8s/testground-daemon/config-map-env-toml.yml
@@ -19,6 +19,15 @@ data:
       "net.core.somaxconn=10000",
     ]
 
+    [runners."cluster:swarm"]
+    disabled = true
+
+    [runners."local:docker"]
+    disabled = true
+
+    [runners."local:exec"]
+    disabled = true
+
     [daemon]
     listen = "0.0.0.0:8042"
     slack_webhook_url = ""


### PR DESCRIPTION
Fixes  #1236

Related testground PR: https://github.com/testground/testground/pull/1405