### PR TITLE
eks: Retry obtaining ALB name/address

### DIFF
--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -420,7 +420,13 @@ tg_daemon_deployment(){
 }
 
 obtain_alb_address(){
-  ALB_ADDRESS=$(kubectl get services -l app=testground-daemon -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}")
+  echo -n "Obtaining ALB address... "
+  ALB_ADDRESS=
+  while [[ -z "${ALB_ADDRESS}" ]]; do
+    ALB_ADDRESS=$(kubectl get services -l app=testground-daemon -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}")
+    sleep 1
+  done
+  echo "Done"
 }
 
 obtain_alb_name(){

--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -424,7 +424,13 @@ obtain_alb_address(){
 }
 
 obtain_alb_name(){
-  ALB_NAME=$(kubectl get services -l app=testground-daemon -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}" | cut -d'-' -f1)
+  echo -n "Obtaining ALB name... "
+  ALB_NAME=
+  while [[ -z "${ALB_NAME}" ]]; do
+    ALB_NAME=$(kubectl get services -l app=testground-daemon -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}" | cut -d'-' -f1)
+    sleep 1
+  done
+  echo "Done"
 }
 
 wait_for_alb_and_instances(){


### PR DESCRIPTION
`ALB_NAME` might be empty due to creating ALB taking time. In order to make sure `ALB_NAME` is not empty I think we need a retry in the `obtain_alb_name()` function.