### PR TITLE
eks: Make install script idempotent

### DIFF
--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -291,9 +291,12 @@ aws_get_sg_id(){
 }
 
 aws_create_efs_mount_point(){
-  aws efs create-mount-target --file-system-id $efs_fs_id --subnet-id $subnet_id --security-group $efs_sg_id --region $REGION
+  mnt_target_id=$(aws efs describe-mount-targets --region $REGION --file-system-id $efs_fs_id | jq -r ".MountTargets[] | .MountTargetId")
+  if [[ -z "${mnt_target_id}" ]]
+  then
+    aws efs create-mount-target --file-system-id $efs_fs_id --subnet-id $subnet_id --security-group $efs_sg_id --region $REGION
+  fi
   efs_dns=$efs_fs_id.efs.$REGION.amazonaws.com
-   
 }
 
 create_cm_efs(){

--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -300,7 +300,9 @@ aws_create_efs_mount_point(){
 }
 
 create_cm_efs(){
-  kubectl create configmap efs-provisioner --from-literal=file.system.id=$efs_fs_id --from-literal=aws.region=$REGION --from-literal=provisioner.name=testground.io/aws-efs
+  if ! kubectl get configmap | grep --quiet efs-provisioner; then
+    kubectl create configmap efs-provisioner --from-literal=file.system.id=$efs_fs_id --from-literal=aws.region=$REGION --from-literal=provisioner.name=testground.io/aws-efs
+  fi
 }
 
 create_efs_manifest(){

--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -302,6 +302,8 @@ aws_create_efs_mount_point(){
 create_cm_efs(){
   if ! kubectl get configmap | grep --quiet efs-provisioner; then
     kubectl create configmap efs-provisioner --from-literal=file.system.id=$efs_fs_id --from-literal=aws.region=$REGION --from-literal=provisioner.name=testground.io/aws-efs
+  else
+    echo "EFS configmap already exists, skipping to the next step."
   fi
 }
 
@@ -345,12 +347,20 @@ helm_redis_add_repo(){
 } 
 
 helm_infra_install_redis(){
-  helm install testground-infra-redis --set auth.enabled=false --set master.nodeSelector='testground.node.role.infra: "true"' bitnami/redis
+  if ! helm ls | grep --quiet testground-infra-redis; then
+    helm install testground-infra-redis --set auth.enabled=false --set master.nodeSelector='testground.node.role.infra: "true"' bitnami/redis
+  else
+    echo "Helm testground-infra-redis already exists, skipping to the next step."
+  fi
 } 
 
 helm_infra_install_influx_db(){
-  helm install influxdb bitnami/influxdb -f $real_path/yaml/influxdb/values.yml --set image.tag=1.8.2 --set image.debug=true --version 2.6.1
-} 
+  if ! helm ls | grep --quiet influxdb; then
+    helm install influxdb bitnami/influxdb -f $real_path/yaml/influxdb/values.yml --set image.tag=1.8.2 --set image.debug=true --version 2.6.1
+  else
+    echo "Helm influxdb already exists, skipping to the next step."
+  fi
+}
 
 tg_daemon_config_map(){
   kubectl apply -f - <<EOF


### PR DESCRIPTION
I often encountered a timeout while `wait_for_alb_and_instances()` and retried the install script. I think it's helpful to make the install script idempotent. 🙂 