### PR TITLE
EKS: fix failure on installing influxdb

### DIFF
--- a/k8s/eks/bash/functions.sh
+++ b/k8s/eks/bash/functions.sh
@@ -385,8 +385,12 @@ helm_infra_install_redis(){
 } 
 
 helm_infra_install_influx_db(){
-  helm install influxdb bitnami/influxdb -f $real_path/yaml/influxdb/values.yml --set image.tag=1.8.2 --set image.debug=true --version 2.6.1
-} 
+  # We are using v2.6.1 of the helm chart, which has been evicted from the regular index.yaml.
+  # Adding the archive-full-index branch to use the old version.
+  # SEE: https://github.com/bitnami/charts/issues/10833
+  helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  helm install influxdb bitnami-full-index/influxdb -f $real_path/yaml/influxdb/values.yml --set image.tag=1.8.2 --set image.debug=true --version 2.6.1
+}
 
 tg_daemon_config_map(){
   kubectl apply -f - <<EOF


### PR DESCRIPTION
Closes https://github.com/testground/testground/issues/1565

I have checked that influxdb has been installed successfully:

```bash
$ ./testground_install.sh
...
...

NAME: influxdb
LAST DEPLOYED: Mon Jan 16 23:40:10 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: influxdb
CHART VERSION: 2.6.1
APP VERSION: 2.1.1

** Please be patient while the chart is being deployed **

InfluxDB&trade; can be accessed through following DNS names from within your cluster:
    InfluxDB&trade;: influxdb.default.svc.cluster.local (port 8086)

To connect to your database run the following commands:

    kubectl run influxdb-client --rm --tty -i --restart='Never' --namespace default  \
        --image docker.io/bitnami/influxdb:1.8.2 \
        --command -- influx -host influxdb -port 8086

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward svc/influxdb 8086:8086 & influx -host 127.0.0.1 -port 8086
WARNING: Rolling tag detected (bitnami/influxdb:1.8.2), please note that it is strongly recommended to avoid using rolling tags in a production environment.
+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/

...
...
```