### PR TITLE
feat: update daemon config and add redeploy utilities to map deployment to config

### DIFF
--- a/k8s/kops/testground-daemon/config-map-env-toml.yml
+++ b/k8s/kops/testground-daemon/config-map-env-toml.yml
@@ -6,39 +6,33 @@ metadata:
 data:
   .env.toml: |
     ["aws"]
-    region = "eu-west-2"
+    region = "eu-west-1"
 
     [runners."cluster:k8s"]
-    run_timeout_min             = 15
+    run_timeout_min             = 45
     testplan_pod_cpu            = "100m"
     testplan_pod_memory         = "100Mi"
-    collect_outputs_pod_cpu     = "1000m"
-    collect_outputs_pod_memory  = "1000Mi"
+    collect_outputs_pod_cpu     = "3000m"
+    collect_outputs_pod_memory  = "3000Mi"
+    autoscaler_enabled          = true
     provider                    = "aws"
     sysctls = [
       "net.core.somaxconn=10000",
     ]
 
-    [runners."cluster:swarm"]
-    disabled = true
-
-    [runners."local:docker"]
-    disabled = true
-
-    [runners."local:exec"]
-    disabled = true
-
     [daemon]
     listen = "0.0.0.0:8042"
     slack_webhook_url = ""
     github_repo_status_token = ""
+    influxdb_endpoint = "http://influxdb:8086"
 
     [daemon.scheduler]
     workers = 2
-    task_timeout_min  = 20
+    task_timeout_min  = 45
     task_repo_type    = "disk"
 
     [client]
     endpoint = "localhost:8080"
+
 ---
 

--- a/k8s/kops/testground-daemon/deployment.yml
+++ b/k8s/kops/testground-daemon/deployment.yml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: testground-daemon
+      annotations:
+        configHash: "74ef22e1f47ec525283fc145915e3effa39dc900c3fc0f3ce5d9ac29d48ad494"
     spec:
       serviceAccountName: testground-daemon
       hostPID: true
@@ -21,64 +23,67 @@ spec:
       nodeSelector:
         testground.node.role.infra: "true"
       initContainers:
-      - name: iproute-add
-        image: busybox:1.31.1
-        securityContext:
-          privileged: true
-        command:
-        - sh
-        - -ac
-        - >
-          while [ "$GW" = "" ]; do export GW=$(ip route | grep cni0 | awk '{print $7}'); echo "Got GW: $GW"; sleep 5; done;
-          echo $GW &&
-          ip route &&
-          ip route add 100.64.0.0/16 via $GW &&
-          ip route || true;
+        - name: iproute-add
+          image: busybox:1.31.1
+          securityContext:
+            privileged: true
+          command:
+            - sh
+            - -ac
+            - >
+              ip route; while [ "$GW" = "" ]; do export GW=$(ip route | grep cni0 | awk '{print $7}'); echo "Got GW: $GW"; sleep 5; done; echo $GW && ip route && ip route add 100.64.0.0/16 via $GW && ip route || true;
+
       containers:
-      - name: goproxy
-        image: iptestground/goproxy:2.0.2
-        ports:
-        - containerPort: 8081
-          hostPort: 8081
-        volumeMounts:
-          - name: envtoml
-            mountPath: /root/testground/.env.toml
-            subPath: .env.toml
-          - name: efs-pvc
-            mountPath: "/go"
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 500m
-          limits:
-            memory: 512Mi
-      - name: testground-daemon
-        image: iptestground/testground:edge
-        imagePullPolicy: Always
-        env:
-        - name: REDIS_HOST
-          value: "testground-infra-redis-headless"
-        securityContext:
-          privileged: true
-        ports:
-        - containerPort: 8042
-          hostPort: 8042
-        volumeMounts:
-          - name: daemon-datadir
-            mountPath: "/root/testground/"
-          - name: efs-pvc
-            mountPath: "/efs"
-          - name: dockersock
-            mountPath: "/var/run/docker.sock"
-          - name: envtoml
-            mountPath: /root/testground/.env.toml
-            subPath: .env.toml
-        resources:
-          requests:
-            memory: 2048Mi
-            cpu: 2000m
-          limits:
-            memory: 2048Mi
+        - name: goproxy
+          image: iptestground/goproxy:2.0.2
+          command:
+            - sh
+            - ac
+            - >
+              echo "we reach this stage actually"; ./bin/goproxy -listen=0.0.0.0:8081 git -cacheDir=/tmp/test;
+
+          ports:
+            - containerPort: 8081
+              hostPort: 8081
+          volumeMounts:
+            - name: envtoml
+              mountPath: /root/testground/.env.toml
+              subPath: .env.toml
+            - name: efs-pvc
+              mountPath: "/go"
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 500m
+            limits:
+              memory: 512Mi
+        - name: testground-daemon
+          image: iptestground/testground:edge
+          imagePullPolicy: Always
+          env:
+            - name: REDIS_HOST
+              value: "testground-infra-redis-headless"
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 8042
+              hostPort: 8042
+          volumeMounts:
+            - name: daemon-datadir
+              mountPath: "/root/testground/"
+            - name: efs-pvc
+              mountPath: "/efs"
+            - name: dockersock
+              mountPath: "/var/run/docker.sock"
+            - name: envtoml
+              mountPath: /root/testground/.env.toml
+              subPath: .env.toml
+          resources:
+            requests:
+              memory: 2048Mi
+              cpu: 2000m
+            limits:
+              memory: 2048Mi
       volumes:
         - name: efs-pvc
           persistentVolumeClaim:

--- a/k8s/kops/tools/redeploy-daemon.sh
+++ b/k8s/kops/tools/redeploy-daemon.sh
@@ -9,11 +9,35 @@ err_report() {
     echo "Error on line $1"
 }
 
+check_yq() {
+    if [[ -z $(which yq) ]]
+    then
+        echo "yq is not installed, you must install it first."
+        exit 1;
+    fi
+}
+
+check_sha256sum() {
+    if [[ -z $(which sha256sum) ]]
+    then
+        echo "sha256sum is not installed, you must install it first."
+        exit 1;
+    fi
+}
+
+update_deployment_config_hash() {
+    shasum=$(kubectl get cm/$3 | sha256sum | cut -d " " -f1)
+    yq -i e ".spec.template.metadata.annotations.$2 |=\"$shasum\"" $1
+}
+
 trap 'err_report $LINENO' ERR
 
+check_yq
+check_sha256sum
 kubectl delete deployment testground-daemon || true
 kubectl delete service testground-daemon || true
 kubectl apply -f config-map-env-toml.yml
+update_deployment_config_hash deployment.yml configHash env-toml-cfg
 kubectl apply -f service-account.yml
 kubectl apply -f role-binding.yml
 kubectl apply -f deployment.yml -f service.yml


### PR DESCRIPTION
## Context

We need to extended the test run timeout to better observe our experiments, and we ran into issues with redeploying the daemon due to an old config that was sitting in this repository.

## Changes

In this PR, we:

- [x] Add a new configuration for the daemon to replace the old one
- [x] Enhance the `k8s/kops/tools/redeploy_daemon.sh` to map the newly deployed config to its relative deployment using the config's sha256sum digest


## Housekeeping

- [x] PR Tested by deploying against the cluster using the redeploy tool (_deployment successful_)
- [x] Redeploy tool tested locally for config update
